### PR TITLE
Fix makeExpectCurriedMockFns()

### DIFF
--- a/src/makeMockCurryFn/utils/makeExpectCurriedMockFns.ts
+++ b/src/makeMockCurryFn/utils/makeExpectCurriedMockFns.ts
@@ -5,11 +5,26 @@ export const makeExpectCurriedMockFns = (
 ) => (...expectedFnArgs: any[]) => {
   const { mockFns, index } = setup
 
-  if (index >= mockFns.length - 1) {
+  doMatchedMockFnAssertion(setup, expectedFnArgs)
+
+  const shouldReturnCurriedFn = index < mockFns.length - 1
+  if (!shouldReturnCurriedFn) {
     return undefined
+  }
+  return makeExpectCurriedMockFns({ ...setup, index: index + 1 })
+}
+
+const doMatchedMockFnAssertion = (
+  setup: MakeExpectCurriedMockFnsSetup,
+  expectedFnArgs: any[]
+): void => {
+  const { mockFns, index } = setup
+
+  const isWithinIndex = index < mockFns.length
+  if (!isWithinIndex) {
+    return
   }
 
   const matchedMockFn = mockFns[index]
   expect(matchedMockFn).toHaveBeenCalledWith(...expectedFnArgs)
-  return makeExpectCurriedMockFns({ ...setup, index: index + 1 })
 }

--- a/src/test/sampleUsage/makeName.ts
+++ b/src/test/sampleUsage/makeName.ts
@@ -1,6 +1,6 @@
 import { stringPrefixer } from './stringPrefixer'
 
-export const makeName = (name) => {
+export const makeName = (name: string) => {
   const prefix = stringPrefixer('first')('second')
   const result = `${prefix} ${name}`
   return result

--- a/src/test/sampleUsage/stringPrefixer.ts
+++ b/src/test/sampleUsage/stringPrefixer.ts
@@ -1,3 +1,3 @@
-export const stringPrefixer = (first) => (second) => {
+export const stringPrefixer = (first: string) => (second: string) => {
   return `${first}-${second}`
 }


### PR DESCRIPTION
Fixes issue outlined in https://github.com/nossbigg/jest-mock-curry-fn/issues/1

Problem:  
- Not asserting on tailFn call

Root Cause:
- Relevant code: https://github.com/nossbigg/jest-mock-curry-fn/blob/4d18a50e2690c2f1bdfb12ab9f7ad9ae92f6d6f8/src/makeMockCurryFn/utils/makeExpectCurriedMockFns.ts#L1-L15
- The correct behavior for `makeExpectCurriedMockFns()` is:
   1. Return mock fn when it is not at the end yet
   2. Return `undefined` when it has reached the end
   2. Do all assertions that are required
- However, In the tail fn call iteration, there is a faulty logic where we fail to perform the assertion for the final curried call.

Solution:
- Assert on tailFn call